### PR TITLE
add workflow entry for building the docker image

### DIFF
--- a/.github/workflows/tests_and_ci.yml
+++ b/.github/workflows/tests_and_ci.yml
@@ -51,6 +51,14 @@ jobs:
           TESTING_MYSQLHOST: 'localhost'
           TESTING_MYSQLPORT: '3800'
 
+  docker-buildable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the image
+        run: |
+          docker build . --tag ghcr.io/thearyadev/top500-aggregator:latest
+
   build_and_publish:
     runs-on: ubuntu-latest
     needs: tests


### PR DESCRIPTION
Docker build process is untested during the testing phase. 
The workflow which builds the image is only in the `build_and_publish` section, which is skipped during PR's. 
This change will ensure that the image is buildable before allowing a merge. 