### PR TITLE
49 add hero color persistance to gui charts

### DIFF
--- a/heroes/hero_comparison.py
+++ b/heroes/hero_comparison.py
@@ -108,6 +108,48 @@ class Heroes:
             "LifeWeaver": "SUPPORT",
         }
 
+        self.hero_colors: dict[str, str] = {
+            "Ana": "#8796B6",
+            "Ashe": "#0E04EA",
+            "Baptiste": "#7DB8CE",
+            "Bastion": "#8c998c",
+            "Blank": "#000000",
+            "Brigitte": "#957D7E",
+            "Cassidy": "#557C7F",
+            "D.Va": "#F59CC8",
+            "Doomfist": "#947F80",
+            "Echo": "#A4CFF9",
+            "Genji": "#9FF67D",
+            "Hanzo": "#BDB894",
+            "Illari": "#B3A58A",
+            "Junker Queen": "#89B2D5",
+            "Junkrat": "#F0BE7C",
+            "Kiriko": "#D4868F",
+            "Lucio": "#91CD7D",
+            "Mei": "#81AFED",
+            "Mercy": "#F4EFBF",
+            "Moira": "#9d86e5",
+            "Orisa": "#76967B",
+            "Pharah": "#768BC8",
+            "Ramattra": "#9B89CE",
+            "Reaper": "#8D797E",
+            "Reinhardt": "#9EA8AB",
+            "Roadhog": "#BC977E",
+            "Sigma": "#9CA7AA",
+            "Sojourn": "#D88180",
+            "Soldier 76": "#838A9C",
+            "Sombra": "#887EBC",
+            "Symmetra": "#98C1D1",
+            "Torbjorn": "#C38786",
+            "Tracer": "#DE9D7D",
+            "Widowmaker": "#A583AB",
+            "Winston": "#A7AABE",
+            "Wrecking Ball": "#E09C7C",
+            "Zarya": "#F291BB",
+            "Zenyatta": "#F5EC91",
+            "LifeWeaver": "#E0B6C5",
+        }
+
     def predict_hero_name(self, image_data: np.ndarray, model_name: str) -> Hero:
         """Predicts the hero name from an image using a neural network model.
 

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 import database
+import heroes
 import leaderboards
 from statistic import (
     get_hero_occurrence_trend,
@@ -454,6 +455,7 @@ async def season(
                 "request": request,
                 "seasons": seasons_list,
                 "currentSeason": season_number,
+                "hero_colors": json.dumps(heroes.Heroes().hero_colors),
                 **seasons_data[season_number],  # type: ignore
                 **seasons_data[season_number]["MISC"],  # type: ignore
                 # this does work. Im not sure why mypy is complaining.
@@ -478,6 +480,7 @@ async def trendsEndpoint(
             "request": request,
             "seasons": seasons_list,
             "trends": json.dumps(trends_data),
+            "hero_colors": json.dumps(heroes.Heroes().hero_colors),
         },
     )
 

--- a/static/js/season.js
+++ b/static/js/season.js
@@ -17,7 +17,7 @@ const charts = [ // define all chart ids here
     'OTMP_DAMAGE_ALL', 'OTMP_TANK_ALL', 'O_ALL_AMERICAS', 'O_ALL_EUROPE',
     'O_ALL_ASIA', 'O_ALL_ALL', 
 ]
-
+const hero_color_data = $("colors").data().herocolors
 function map_multi_array(arrayOfObjects){
     const heroes = [];
     const counts = [];
@@ -65,7 +65,12 @@ function drawChart(chartName) {
         series: [
             {
                 name: `::`,
-                data: counts
+                data: counts.map(item => {
+                    return {
+                        y: item,
+                        color: lookup_hero_color(heroes[counts.indexOf(item)])
+                        }
+                })
             },
         ]
     });
@@ -74,6 +79,14 @@ function drawChart(chartName) {
     chartElement.parent().append(`<p class='chart-stats small text-muted'><small>Mean: ${stats?.mean} | Variance: ${stats?.variance} | Standard Deviation: ${stats?.standard_deviation} | # Entires: ${counts.reduce((acc, cur) => acc + cur, 0)}</small></p>`)
 
 }
+
+
+function lookup_hero_color(name){
+    return hero_color_data[name] || "black"
+}
+
+
+
 
 let lastWidth = window.innerWidth;
 

--- a/static/js/trends.js
+++ b/static/js/trends.js
@@ -1,3 +1,7 @@
+
+const hero_color_data = $("colors").data().herocolors
+
+
 function drawHeroTrendChartAllRegions() {
     const chartElement = $('#T_ALL_ALL')
     const data = $('data').data().trends
@@ -35,7 +39,13 @@ Highcharts.chart('T_ALL_ALL', {
 
 
 
-    series: data,
+    series: data.map(item => {
+    console.log(item)
+     return {
+        color: lookup_hero_color(item.name),
+        ...item
+        }
+    }),
     responsive: {
         rules: [{
             condition: {
@@ -68,3 +78,7 @@ window.addEventListener('resize', function () { // redraw charts on resize
     }
 
 });
+
+function lookup_hero_color(name){
+    return hero_color_data[name] || "black"
+}

--- a/templates/season.html
+++ b/templates/season.html
@@ -26,6 +26,8 @@
     }
 
 </style>
+
+<colors style="display: none;" data-herocolors="{{ hero_colors }}"></colors>
 <main class="body">
     <section id="hero_occ_all" class="section-box d-flex flex-row flex-wrap card ">
         <h2 class="section-title">Hero Occurrences: All Slots</h2>

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -26,6 +26,7 @@
 <main class="body">
     <data data-trends="{{trends}}"></data>
     <seasons style="display: none;" data-seasons="{{ seasons }}"></seasons>
+    <colors style="display: none;" data-herocolors="{{ hero_colors  }}"></colors>
     <section id="hero_occ_all" class="section-box d-flex flex-row flex-wrap card ">
         <!-- <h2 class="section-title">All Heroes: By Region</h2> -->
         <div class="break p-5"></div>


### PR DESCRIPTION
This PR adds color persistence to all charts. 

Colors are referenced from the in-game career profile colors.

<img width="1168" alt="Screenshot 2023-12-14 at 8 34 00 PM" src="https://github.com/thearyadev/top500-aggregator/assets/87589047/90a36780-2798-4391-8b1d-9b07f4403645">

<img width="1180" alt="Screenshot 2023-12-14 at 8 33 44 PM" src="https://github.com/thearyadev/top500-aggregator/assets/87589047/213f1283-a2c4-4f56-bf93-4cb8dff582f9">
