### PR TITLE
Use tracked index instead of calculated index.

### DIFF
--- a/static/js/season.js
+++ b/static/js/season.js
@@ -74,10 +74,10 @@ function drawChart(chartName) {
         series: [
             {
                 name: `Occurrences`,
-                data: counts.map(item => {
+                data: counts.map((item, index) => {
                     return {
                         y: item,
-                        color: lookup_hero_color(heroes[counts.indexOf(item)])
+                        color: lookup_hero_color(heroes[index])
                         }
                 })
             },


### PR DESCRIPTION
When creating the charts and determining what color each column should be, the script looks up the color of the hero. 

```js
counts.map((item) => {
                    return {
                        y: item,
                        color: lookup_hero_color(heroes[counts.indexOf(item)])
                        }
                })
```
In this case, `item` is the integer value of the column, which is looked up in the array of `counts` which corresponds to the array of labels. The issue here is, `indexOf` will find the first matching value, so if there is a duplicate, the first index will appear only. 

The issue here is, Widowmaker and tracer both had a value of 136, causing widowmaker to pick up tracer's color. 

Fixed code: 
Using the `(item, index)` of `array.map`
```js
counts.map((item, index) => {
                    return {
                        y: item,
                        color: lookup_hero_color(heroes[index])
                        }
                })
```