### PR TITLE
Fix incorrect season number on index page (temporary solution)

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -31,7 +31,7 @@ function MyApp({Component, pageProps}: T500AggregatorAppProps) {
         <>
             <Header nav_links={links}/>
             <main className="mt-5 lg:ml-3 lg:mr-3 sm:ml-1 sm:mr-1">
-                <h2 className={"text-4xl pb-4"}>{seasonNumber? `Season ${seasonNumber}`: path.toLowerCase().includes("trends") ? "Trends" : "Season 8"}</h2>
+                <h2 className={"text-4xl pb-4"}>{seasonNumber? `Season ${seasonNumber}`: path.toLowerCase().includes("trends") ? "Trends" : "Season 7"}</h2>
 
                 <p className="pb-2"><strong>Welcome to Overwatch 2 Top 500 Aggregator</strong></p>
                 <p>The data available on this page is not 100% accurate. Data collection involves computer vision and


### PR DESCRIPTION
The `/` route on the new front end displays the incorrect season number. It displays 8 instead of 7. 

This is an issue related to #89. 

The change to an SSR framework has required that i temporarily change how the header info is handled. For now, i have to hard code the available seasons and the current season. 

This PR addresses #96 with a temporarily solution to help reduce the confusion.