### PR TITLE
Add non-root user to all containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   nginx:
     image: nginx:latest
+    user: '1000:1000'
     depends_on:
       - server
     volumes:
@@ -13,6 +14,7 @@ services:
 
       image: ghcr.io/thearyadev/top500-aggregator-server:latest
       #    build: .
+      user: '1000:1000'
       environment:
         MYSQLDATABASE: 'railway'
         MYSQLUSER: 'root'
@@ -26,9 +28,11 @@ services:
     image: ghcr.io/thearyadev/top500-aggregator-frontend:latest
     ports:
       - "3000:3000"
+    user: "1000:1000"
   # these services are internal, so secrets do not matter.
   database:
     image: mysql@sha256:566007208a3f1cc8f9df6b767665b5c9b800fc4fb5f863d17aa1df362880ed04
+    user: "1000:1000"
     environment:
       MYSQL_DATABASE: 'railway'
       MYSQL_USER: 't5aggr'


### PR DESCRIPTION
all containers have been running as root. This is a vulnerability as the Nginx server is port forwarded, and the server has a lot of capabilities on the local network. 
